### PR TITLE
optimise `_between_residue_clash_loss` function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dev = [
     "ruff",
     # static typing
     "mypy",
+    # testing
+    "pytest",
 ]
 
 [project.urls]

--- a/swiftmhc/loss.py
+++ b/swiftmhc/loss.py
@@ -12,9 +12,11 @@ from openfold.np.residue_constants import (
 from openfold.np.residue_constants import (
     restype_atom14_ambiguous_atoms as openfold_restype_atom14_ambiguous_atoms,
 )
+from openfold.np.residue_constants import (
+    restype_name_to_atom14_names as openfold_restype_name_to_atom14_names,
+)
 from openfold.np.residue_constants import van_der_waals_radius as openfold_van_der_waals_radius
 from openfold.utils.loss import between_residue_bond_loss as openfold_between_residue_bond_loss
-from openfold.utils.loss import between_residue_clash_loss as openfold_between_residue_clash_loss
 from openfold.utils.loss import compute_fape as openfold_compute_fape
 from openfold.utils.loss import (
     compute_renamed_ground_truth as openfold_compute_renamed_ground_truth,
@@ -126,6 +128,228 @@ def _compute_fape_loss(
     }
 
 
+def _between_residue_clash_loss(
+    atom14_pred_positions: torch.Tensor,
+    atom14_atom_exists: torch.Tensor,
+    atom14_atom_radius: torch.Tensor,
+    residue_index: torch.Tensor,
+    asym_id: torch.Tensor | None = None,
+    overlap_tolerance_soft=1.5,
+    overlap_tolerance_hard=1.5,
+    eps=1e-10,
+    max_distance_cutoff=15.0,
+    chunk_size: int = 32,
+) -> dict[str, torch.Tensor]:
+    """Memory-optimized clash loss with distance cutoff.
+
+    Args:
+        atom14_pred_positions: Predicted positions of atoms in global prediction frame
+        atom14_atom_exists: Mask denoting whether atom at positions exists for given amino acid type
+        atom14_atom_radius: Van der Waals radius for each atom
+        residue_index: Residue index for given amino acid
+        asym_id: Asymmetric unit ID for each residue
+        overlap_tolerance_soft: Soft tolerance factor
+        overlap_tolerance_hard: Hard tolerance factor
+        eps: Small epsilon for numerical stability
+        max_distance_cutoff: Maximum distance to consider for clash detection.
+            Atom pairs further apart than this are ignored.
+        chunk_size: Number of residues to process at once to control memory usage
+
+    Returns:
+        Dict containing:
+            * 'mean_loss': average clash loss
+            * 'per_atom_loss_sum': sum of all clash losses per atom, shape (N, 14)
+            * 'per_atom_clash_mask': mask whether atom clashes with any other atom
+                shape (N, 14)
+            * 'per_atom_num_clash': number of clashes per atom, shape (N, 14)
+    """
+    fp_type = atom14_pred_positions.dtype
+    device = atom14_pred_positions.device
+    batch_dims = atom14_pred_positions.shape[:-3]
+    n_residues = atom14_pred_positions.shape[-3]
+
+    # Initialize accumulation tensors
+    total_loss_sum = torch.zeros((), dtype=fp_type, device=device)
+    total_mask_sum = torch.zeros((), dtype=fp_type, device=device)
+    per_atom_loss_sum = torch.zeros((*batch_dims, n_residues, 14), dtype=fp_type, device=device)
+    per_atom_clash_mask = torch.zeros((*batch_dims, n_residues, 14), dtype=fp_type, device=device)
+    per_atom_num_clash = torch.zeros((*batch_dims, n_residues, 14), dtype=fp_type, device=device)
+
+    # Pre-compute residue center of mass for distance-based early termination
+    # Shape: (..., N, 3)
+    residue_com = torch.sum(atom14_pred_positions * atom14_atom_exists[..., None], dim=-2) / (
+        torch.sum(atom14_atom_exists, dim=-1, keepdim=True) + eps
+    )
+
+    # Pre-compute one-hot encodings for bond masking
+    c_one_hot = torch.nn.functional.one_hot(residue_index.new_tensor(2), num_classes=14)
+    c_one_hot = c_one_hot.reshape(*((1,) * len(residue_index.shape[:-1])), *c_one_hot.shape).type(
+        fp_type
+    )
+    n_one_hot = torch.nn.functional.one_hot(residue_index.new_tensor(0), num_classes=14)
+    n_one_hot = n_one_hot.reshape(*((1,) * len(residue_index.shape[:-1])), *n_one_hot.shape).type(
+        fp_type
+    )
+
+    # Pre-compute cysteine disulfide bond mask
+    cys = openfold_restype_name_to_atom14_names["CYS"]
+    cys_sg_idx = cys.index("SG")
+    cys_sg_idx = residue_index.new_tensor(cys_sg_idx)
+    cys_sg_idx = cys_sg_idx.reshape(*((1,) * len(residue_index.shape[:-1])), 1).squeeze(-1)
+    cys_sg_one_hot = torch.nn.functional.one_hot(cys_sg_idx, num_classes=14)
+
+    # Pre-allocate reusable tensors to reduce memory allocation overhead
+    max_chunk = chunk_size
+    # Pre-allocate distance tensor (reused across iterations)
+    dists_buffer = torch.full(
+        (*batch_dims, max_chunk, max_chunk, 14, 14),
+        max_distance_cutoff + 1.0,
+        dtype=fp_type,
+        device=device,
+    )
+
+    # Process residues in chunks to avoid O(N²) memory usage
+    for i_start in range(0, n_residues, chunk_size):
+        i_end = min(i_start + chunk_size, n_residues)
+        i_chunk_size = i_end - i_start  # Actual chunk size (might be smaller than chunk_size)
+
+        i_chunk_positions = atom14_pred_positions[..., i_start:i_end, :, :]
+        i_chunk_exists = atom14_atom_exists[..., i_start:i_end, :]
+        i_chunk_radius = atom14_atom_radius[..., i_start:i_end, :]
+        i_chunk_residue_idx = residue_index[..., i_start:i_end]
+        i_chunk_asym_id = asym_id[..., i_start:i_end] if asym_id is not None else None
+        i_chunk_com = residue_com[..., i_start:i_end, :]
+
+        for j_start in range(i_start, n_residues, chunk_size):  # Only upper triangle
+            j_end = min(j_start + chunk_size, n_residues)
+            j_chunk_size = j_end - j_start  # Actual chunk size (might be smaller than chunk_size)
+
+            j_chunk_positions = atom14_pred_positions[..., j_start:j_end, :, :]
+            j_chunk_exists = atom14_atom_exists[..., j_start:j_end, :]
+            j_chunk_radius = atom14_atom_radius[..., j_start:j_end, :]
+            j_chunk_residue_idx = residue_index[..., j_start:j_end]
+            j_chunk_asym_id = asym_id[..., j_start:j_end] if asym_id is not None else None
+            j_chunk_com = residue_com[..., j_start:j_end, :]
+
+            # Early termination: check residue center-of-mass distances
+            # Shape: (..., i_chunk_size, j_chunk_size)
+            com_distances_sq = torch.sum(
+                (i_chunk_com[..., :, None, :] - j_chunk_com[..., None, :, :]) ** 2, dim=-1
+            )
+            close_residue_pairs = com_distances_sq < (max_distance_cutoff**2)
+
+            # Only consider pairs where i_residue_idx < j_residue_idx (upper triangular)
+            residue_pair_mask = (
+                i_chunk_residue_idx[..., :, None] < j_chunk_residue_idx[..., None, :]
+            )
+            close_residue_pairs = close_residue_pairs & residue_pair_mask
+
+            # Reuse pre-allocated buffer and reset for current chunks
+            dists_buffer.fill_(max_distance_cutoff + 1.0)
+            dists = dists_buffer[..., :i_chunk_size, :j_chunk_size, :, :]
+
+            # Compute distances for all pairs (masked computation)
+            close_mask = close_residue_pairs[..., None, None]
+            pos_diff = (
+                i_chunk_positions[..., :, None, :, None, :]
+                - j_chunk_positions[..., None, :, None, :, :]
+            )
+            # Use torch.linalg.vector_norm for more efficient distance computation
+            actual_dists = torch.linalg.vector_norm(pos_diff, dim=-1) + eps
+
+            # Apply masking to distances
+            dists = torch.where(close_mask, actual_dists, dists)
+
+            # Create mask for valid atom pairs
+            dists_mask = (
+                i_chunk_exists[..., :, None, :, None]
+                * j_chunk_exists[..., None, :, None, :]
+                * close_residue_pairs[..., :, :, None, None]
+            ).type(fp_type)
+
+            # Skip C-N bonds between consecutive residues
+            # Fix the condition to handle chunk boundaries properly
+            if j_start <= i_end:  # Only check when chunks might contain consecutive residues
+                neighbour_mask = (i_chunk_residue_idx[..., :, None] + 1) == j_chunk_residue_idx[
+                    ..., None, :
+                ]
+                if i_chunk_asym_id is not None and j_chunk_asym_id is not None:
+                    neighbour_mask = neighbour_mask & (
+                        i_chunk_asym_id[..., :, None] == j_chunk_asym_id[..., None, :]
+                    )
+
+                neighbour_mask = neighbour_mask[..., None, None]
+                c_n_bonds = (
+                    neighbour_mask
+                    * c_one_hot[..., None, None, :, None]
+                    * n_one_hot[..., None, None, None, :]
+                )
+                dists_mask = dists_mask * (1.0 - c_n_bonds)
+
+            # Skip disulfide bonds
+            disulfide_bonds = (
+                cys_sg_one_hot[..., None, None, :, None] * cys_sg_one_hot[..., None, None, None, :]
+            )
+            dists_mask = dists_mask * (1.0 - disulfide_bonds)
+
+            # Use masking for torch.compile compatibility
+            # Compute distance bounds
+            dists_lower_bound = dists_mask * (
+                i_chunk_radius[..., :, None, :, None] + j_chunk_radius[..., None, :, None, :]
+            )
+
+            # Compute soft clash loss
+            dists_to_low_error = dists_mask * torch.nn.functional.relu(
+                dists_lower_bound - overlap_tolerance_soft - dists
+            )
+
+            # Use in-place operations for memory efficiency
+            total_loss_sum.add_(dists_to_low_error.sum())
+            total_mask_sum.add_(dists_mask.sum())
+
+            # Accumulate per-atom losses (both directions since we only process upper triangle)
+            i_atom_loss = dists_to_low_error.sum(dim=(-3, -1))
+            j_atom_loss = dists_to_low_error.sum(dim=(-4, -2))
+
+            per_atom_loss_sum[..., i_start:i_end, :].add_(i_atom_loss)
+            per_atom_loss_sum[..., j_start:j_end, :].add_(j_atom_loss)
+
+            # Compute hard clash mask
+            clash_mask = dists_mask * (dists < (dists_lower_bound - overlap_tolerance_hard))
+
+            # Accumulate clash counts using in-place operations
+            i_clash_count = clash_mask.sum(dim=(-3, -1)).float()  # Sum over j_residues and j_atoms
+            j_clash_count = clash_mask.sum(dim=(-4, -2)).float()  # Sum over i_residues and i_atoms
+
+            per_atom_num_clash[..., i_start:i_end, :].add_(i_clash_count)
+            per_atom_num_clash[..., j_start:j_end, :].add_(j_clash_count)
+
+            # Update clash mask (any clash detected) using in-place operations
+            i_has_clash = torch.amax(clash_mask, dim=(-3, -1)).float()  # Any clash with j_residues
+            j_has_clash = torch.amax(clash_mask, dim=(-4, -2)).float()  # Any clash with i_residues
+
+            torch.maximum(
+                per_atom_clash_mask[..., i_start:i_end, :],
+                i_has_clash,
+                out=per_atom_clash_mask[..., i_start:i_end, :],
+            )
+            torch.maximum(
+                per_atom_clash_mask[..., j_start:j_end, :],
+                j_has_clash,
+                out=per_atom_clash_mask[..., j_start:j_end, :],
+            )
+
+    # Compute final mean loss
+    mean_loss = total_loss_sum / (1e-6 + total_mask_sum)
+
+    return {
+        "mean_loss": mean_loss,  # shape ()
+        "per_atom_loss_sum": per_atom_loss_sum,  # shape (N, 14)
+        "per_atom_clash_mask": per_atom_clash_mask,  # shape (N, 14)
+        "per_atom_num_clash": per_atom_num_clash,  # shape (N, 14)
+    }
+
+
 def _compute_cross_violation_loss(
     output: dict[str, torch.Tensor],
     batch: dict[str, torch.Tensor],
@@ -174,7 +398,7 @@ def _compute_cross_violation_loss(
     # [*, peptide_maxlen + protein_maxlen]
     residue_index = torch.cat((peptide_residue_index, protein_residue_index), dim=1)
 
-    between_residue_clashes = openfold_between_residue_clash_loss(
+    between_residue_clashes = _between_residue_clash_loss(
         atom14_pred_positions=atom14_pred_positions,
         atom14_atom_exists=atom14_atom_exists,
         atom14_atom_radius=atom14_atom_radius,

--- a/tests/unit/test_loss.py
+++ b/tests/unit/test_loss.py
@@ -1,0 +1,73 @@
+# from .config import consts
+import ml_collections as mlc
+import torch
+from openfold.utils.loss import between_residue_clash_loss as openfold_between_residue_clash_loss
+from swiftmhc.loss import _between_residue_clash_loss as between_residue_clash_loss
+
+
+consts = mlc.ConfigDict(
+    {
+        "batch_size": 2,
+        "n_res": 22,
+        "eps": 5e-4,
+    }
+)
+
+
+def test_run_between_residue_clash_loss():
+    bs = consts.batch_size
+    n = consts.n_res
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    pred_pos = torch.rand(bs, n, 14, 3, device=device, dtype=dtype).float()  # shape (2, 22, 14, 3)
+    pred_atom_mask = torch.randint(
+        0, 2, (bs, n, 14), device=device, dtype=dtype
+    ).float()  # shape (2, 22, 14)
+    atom14_atom_radius = torch.rand(
+        bs, n, 14, device=device, dtype=dtype
+    ).float()  # shape (2, 22, 14)
+
+    residue_index = torch.arange(n, device=device).unsqueeze(0)  # shape (1, 22)
+
+    between_residue_clash_loss(
+        pred_pos,
+        pred_atom_mask,
+        atom14_atom_radius,
+        residue_index,
+    )
+
+
+def test_run_between_residue_clash_loss_compare():
+    """Compare with OpenFold implementation"""
+    bs = consts.batch_size
+    n = consts.n_res
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    pred_pos = torch.rand(bs, n, 14, 3, device=device, dtype=dtype).float()  # shape (2, 22, 14, 3)
+    pred_atom_mask = torch.randint(
+        0, 2, (bs, n, 14), device=device, dtype=dtype
+    ).float()  # shape (2, 22, 14)
+    atom14_atom_radius = torch.rand(
+        bs, n, 14, device=device, dtype=dtype
+    ).float()  # shape (2, 22, 14)
+    residue_index = torch.arange(n, device=device).unsqueeze(0)  # shape (1, 22)
+
+    loss_expected = openfold_between_residue_clash_loss(
+        pred_pos,
+        pred_atom_mask,
+        atom14_atom_radius,
+        residue_index,
+    )
+
+    loss_actual = between_residue_clash_loss(
+        pred_pos,
+        pred_atom_mask,
+        atom14_atom_radius,
+        residue_index,
+    )
+
+    for k in loss_expected.keys():
+        print(k)
+        assert torch.allclose(loss_expected[k], loss_actual[k], atol=consts.eps)


### PR DESCRIPTION
Openfold `between_residue_clash_loss` function is a key hotspot of memory cost in swiftmhc with a complexity O(N^2). 

This PR optimised this function to save memory and compute with following tricks:
1. Compute by chunks instead of full input  
2. Pair distance is symmetrical, so only computing upper triangle to save compute and memory 
3. Use in-place operations (e.g. `_add`) to save memory
4. and other tricks to keep torch.compile friendly

Unit tests have been added to compare with openfold implementation.

### Performance

With batch size 64, the peak memory is reduced from 28GB (openfold) to 8GB (optimised), and training speeds are similar.
Increasing batch size from 64 to 256, the peak memory is 31GB, leading to 2.3X speedup of training speed.
