### PR TITLE
add data load timer

### DIFF
--- a/scripts/swiftmhc_run.py
+++ b/scripts/swiftmhc_run.py
@@ -1345,7 +1345,6 @@ if __name__ == "__main__":
 
     # Make sure we can use multiple workers:
     _log.debug(f"using {args.workers} workers")
-    torch.multiprocessing.set_start_method("spawn")
 
     # Init trainer object with given arguments
     trainer = Trainer(device, float_dtype, args.workers, model_type)

--- a/scripts/swiftmhc_run.py
+++ b/scripts/swiftmhc_run.py
@@ -597,10 +597,14 @@ class Trainer:
             profiler: Optional profiler instance to step
         """
         torch.cuda.reset_peak_memory_stats()
+        dataload_time = []
         batch_time = []
-        for batch_index, batch_data in enumerate(data_loader):
-            time_start = timer()
 
+        dataload_time_start = timer()
+        for batch_index, batch_data in enumerate(data_loader):
+            dataload_time.append(timer() - dataload_time_start)
+
+            batch_time_start = timer()
             # Transfer batch to device
             batch_data = {
                 k: v.to(self._device, non_blocking=True) if isinstance(v, torch.Tensor) else v
@@ -619,9 +623,7 @@ class Trainer:
             )
 
             # measure time taken
-            step_time = timer() - time_start
-            batch_time.append(step_time)
-            _log.info(f"batch time (s): {step_time:.6f}")
+            batch_time.append(timer() - batch_time_start)
 
             # make the snapshot, if requested
             if animated_data is not None and (batch_index + 1) % self._snap_period == 0:
@@ -639,6 +641,16 @@ class Trainer:
             if profiler is not None:
                 profiler.step()
 
+            dataload_time_start = timer()
+
+        for i in dataload_time:
+            _log.info(f"data load time (s): {i:.6f}")
+        _log.info(
+            f"data load time stat (s): mean {numpy.mean(dataload_time):.6f}, max {numpy.max(dataload_time):.6f}, min {numpy.min(dataload_time):.6f}"
+        )
+
+        for i in batch_time:
+            _log.info(f"batch time (s): {i:.6f}")
         _log.info(
             f"batch time stat (s): mean {numpy.mean(batch_time):.6f}, max {numpy.max(batch_time):.6f}, min {numpy.min(batch_time):.6f}"
         )

--- a/swiftmhc/dataset.py
+++ b/swiftmhc/dataset.py
@@ -73,7 +73,8 @@ class ProteinLoopDataset(Dataset):
             return self._hdf5_file
         else:
             try:
-                self._hdf5_file = h5py.File(self._hdf5_path, "r")
+                # "stdio" driver is faster for many small reads (<64KB)
+                self._hdf5_file = h5py.File(self._hdf5_path, "r", driver="stdio")
             except Exception as e:
                 raise RuntimeError(f"Failed to open HDF5 file {self._hdf5_path}: {str(e)}")
         return self._hdf5_file


### PR DESCRIPTION
add data load timer

opt: remove setting of multiprocessing start method

Let the OS choose the method automatically. Linux will use fork, which is faster than spawn method.

opt: refactor collate function

opt: keep hdf5 file handle alive within a Dataset instance

opt: keep hdf5 filehandle alive

opt: refactor _get_structural_data function

opt: use hdf5 "stdio" driver for many small reads

opt: remove hdf5 instance from init to make workers work